### PR TITLE
feat(users): Add new fields for better user tracking

### DIFF
--- a/migrations/Version20250121083649.php
+++ b/migrations/Version20250121083649.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250121083649 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE users ADD last_login DATETIME NOT NULL, ADD created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', ADD updated_at DATETIME NOT NULL, DROP date_create, DROP last_connect');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE users ADD date_create DATETIME NOT NULL, ADD last_connect DATETIME NOT NULL, DROP last_login, DROP created_at, DROP updated_at');
+    }
+}

--- a/src/Entity/Users.php
+++ b/src/Entity/Users.php
@@ -24,10 +24,18 @@ class Users
     private ?string $password = null;
 
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
-    private ?\DateTimeInterface $dateCreate = null;
+    private ?\DateTimeInterface $lastLogin = null;
+
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private ?\DateTimeImmutable $createdAt = null;
 
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
-    private ?\DateTimeInterface $lastConnect = null;
+    private ?\DateTimeInterface $updatedAt = null;
+
+    public function __construct(){
+        $this->createdAt=new \DateTimeImmutable();
+    }
 
     public function getId(): ?int
     {
@@ -70,26 +78,41 @@ class Users
         return $this;
     }
 
-    public function getDateCreate(): ?\DateTimeInterface
+
+
+    public function getLastLogin(): ?\DateTimeInterface
     {
-        return $this->dateCreate;
+        return $this->lastLogin;
     }
 
-    public function setDateCreate(\DateTimeInterface $dateCreate): static
+    public function setLastLogin(\DateTimeInterface $lastLogin): static
     {
-        $this->dateCreate = $dateCreate;
+        $this->lastLogin = $lastLogin;
 
         return $this;
     }
 
-    public function getLastConnect(): ?\DateTimeInterface
+
+    public function getCreatedAt(): ?\DateTimeImmutable
     {
-        return $this->lastConnect;
+        return $this->createdAt;
     }
 
-    public function setLastConnect(\DateTimeInterface $lastConnect): static
+    public function setCreatedAt(\DateTimeImmutable $createdAt): static
     {
-        $this->lastConnect = $lastConnect;
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?\DateTimeInterface
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(\DateTimeInterface $updatedAt): static
+    {
+        $this->updatedAt = $updatedAt;
 
         return $this;
     }


### PR DESCRIPTION
Added new fields to the 'users' table to enhance user tracking: last_login: stores the last login  datetime of a user created_at in place of date_create
updated_at in place of last_connect